### PR TITLE
Add initial Chrome Extension skeleton with i18n support

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,9 @@ This helps turn design thoughts and discussions into reusable artifacts.
 
 ## Notes
 
+-   Default locale is **Japanese (ja)**.  
+-   i18n is prepared with `_locales/` so that English or other languages can be added easily.  
+-   Forks or future extensions can localize by editing `messages.json`.  
 -   Minimal PoC goal: **voice → structuring → display** loop.\
 -   Future direction: integrations, richer UI, team workflows.\
 -   License: MIT (see [LICENSE](./LICENSE))

--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -1,0 +1,14 @@
+{
+  "extName": {
+    "message": "ai-voice-archiver-x"
+  },
+  "extDescription": {
+    "message": "PoC Chrome Extension: archive voice with AI, output as Markdown/JSON"
+  },
+  "recordStart": {
+    "message": "Start Recording"
+  },
+  "recordStop": {
+    "message": "Stop Recording"
+  }
+}

--- a/_locales/ja/messages.json
+++ b/_locales/ja/messages.json
@@ -1,0 +1,14 @@
+{
+  "extName": {
+    "message": "ai-voice-archiver-x"
+  },
+  "extDescription": {
+    "message": "音声をAIでアーカイブ・構造化し、Markdown/JSONで出力するPoC拡張機能"
+  },
+  "recordStart": {
+    "message": "録音開始"
+  },
+  "recordStop": {
+    "message": "録音停止"
+  }
+}

--- a/background.js
+++ b/background.js
@@ -1,0 +1,6 @@
+chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
+  if (message.type === "TRANSCRIPT") {
+    console.log("Received transcript:", message.data);
+    // TODO: integrate GitHub Models API call later
+  }
+});

--- a/manifest.json
+++ b/manifest.json
@@ -1,0 +1,14 @@
+{
+  "manifest_version": 3,
+  "name": "__MSG_extName__",
+  "version": "0.0.1",
+  "description": "__MSG_extDescription__",
+  "default_locale": "ja",
+  "permissions": ["storage"],
+  "action": {
+    "default_popup": "popup.html"
+  },
+  "background": {
+    "service_worker": "background.js"
+  }
+}

--- a/popup.html
+++ b/popup.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+  <meta charset="UTF-8" />
+  <title>ai-voice-archiver-x</title>
+</head>
+<body>
+  <h1>ai-voice-archiver-x</h1>
+  <button id="recordBtn" data-i18n="recordStart"></button>
+  <pre id="output"></pre>
+  <script src="popup.js"></script>
+</body>
+</html>

--- a/popup.js
+++ b/popup.js
@@ -1,0 +1,41 @@
+const recordBtn = document.getElementById("recordBtn");
+const output = document.getElementById("output");
+
+let recognizing = false;
+let recognition;
+
+function applyI18n() {
+  document.querySelectorAll("[data-i18n]").forEach((el) => {
+    const key = el.getAttribute("data-i18n");
+    el.textContent = chrome.i18n.getMessage(key);
+  });
+}
+
+document.addEventListener("DOMContentLoaded", applyI18n);
+
+if ("webkitSpeechRecognition" in window) {
+  recognition = new webkitSpeechRecognition();
+  recognition.lang = "ja-JP";
+  recognition.interimResults = false;
+
+  recognition.onresult = (event) => {
+    const transcript = event.results[0][0].transcript;
+    output.textContent = transcript;
+    chrome.runtime.sendMessage({ type: "TRANSCRIPT", data: transcript });
+  };
+}
+
+recordBtn.addEventListener("click", () => {
+  if (!recognition) {
+    alert("SpeechRecognition API not supported in this browser.");
+    return;
+  }
+  if (!recognizing) {
+    recognition.start();
+    recordBtn.textContent = chrome.i18n.getMessage("recordStop");
+  } else {
+    recognition.stop();
+    recordBtn.textContent = chrome.i18n.getMessage("recordStart");
+  }
+  recognizing = !recognizing;
+});


### PR DESCRIPTION
### Summary
- Added minimal Chrome Extension skeleton (Manifest V3).
- Implemented initial i18n setup (default locale: Japanese, fallback: English).

### Details
- **manifest.json**
  - Defines base extension metadata.
  - Uses `__MSG_` placeholders for name/description.
  - Default locale set to `ja`.
- **popup.html / popup.js**
  - Minimal UI with record button.
  - Voice input captured via Web Speech API (ja-JP).
  - Transcript displayed in popup and logged to console.
  - Button labels loaded from `chrome.i18n.getMessage`.
- **background.js**
  - Stub to receive transcripts.
  - Ready for future GitHub Models API integration.
- **_locales/**
  - `ja/messages.json`: full Japanese translations.
  - `en/messages.json`: minimal English fallback.

### Acceptance
- Extension can be loaded in Chrome via unpacked mode.
- Record button starts/stops transcription.
- Transcript appears in popup and is logged to console.
- UI text switches properly between Japanese and English.

### Next Steps
- Connect background.js to GitHub Models API for transcript structuring.
- Expand i18n as new UI strings are added.
